### PR TITLE
Update leptos and wasm-bindgen versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ lto = true
 opt-level = 'z'
 
 [workspace.dependencies]
-leptos = { version = "0.7.0-rc1"{% if nightly == "Yes" %}, features = ["nightly"]{% endif %} }
-leptos_meta = { version = "0.7.0-rc1"}
-leptos_router = { version = "0.7.0-rc1"{% if nightly == "Yes" %}, features = ["nightly"]{% endif %} }
-leptos_axum = { version = "0.7.0-rc1" }
+leptos = { version = "0.7.3"{% if nightly == "Yes" %}, features = ["nightly"]{% endif %} }
+leptos_meta = { version = "0.7.3"}
+leptos_router = { version = "0.7.3"{% if nightly == "Yes" %}, features = ["nightly"]{% endif %} }
+leptos_axum = { version = "0.7.3" }
 
 axum = "0.7"
 cfg-if = "1"
@@ -25,7 +25,7 @@ thiserror = "1"
 tokio = { version = "1.33.0", features = ["full"] }
 tower = { version = "0.4.13", features = ["full"] }
 tower-http = { version = "0.5", features = ["full"] }
-wasm-bindgen = "=0.2.95"
+wasm-bindgen = "=0.2.100"
 
 # See https://github.com/akesson/cargo-leptos for documentation of all the parameters.
 


### PR DESCRIPTION
Updated the versions of leptos crates and wasm-bindgen crates. 
I've tested by generating a new project using the `--path` option, i.e. `cargo leptos new --path ./start-axum-workspace-0.7/`.
No errors were visible in the browser console. 
There was a note in the browser console: "Note: `cargo-leptos watch --hot-reload` only works with the `nightly` feature enabled on Leptos." when I ran `cargo leptos watch`.  
Note: I had to `cargo leptos build` prior to running `cargo leptos watch` as some file was not generated.