### PR TITLE
Update numerous deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ lto = true
 opt-level = 'z'
 
 [workspace.dependencies]
-leptos = { version = "0.7.0-rc1"{% if nightly == "Yes" %}, features = ["nightly"]{% endif %} }
-leptos_meta = { version = "0.7.0-rc1"}
-leptos_router = { version = "0.7.0-rc1"{% if nightly == "Yes" %}, features = ["nightly"]{% endif %} }
-leptos_axum = { version = "0.7.0-rc1" }
+leptos = { version = "0.7.3"{% if nightly == "Yes" %}, features = ["nightly"]{% endif %} }
+leptos_meta = { version = "0.7.3"}
+leptos_router = { version = "0.7.3"{% if nightly == "Yes" %}, features = ["nightly"]{% endif %} }
+leptos_axum = { version = "0.7.3" }
 
 axum = "0.7"
 cfg-if = "1"
@@ -25,7 +25,7 @@ thiserror = "1"
 tokio = { version = "1.33.0", features = ["full"] }
 tower = { version = "0.4.13", features = ["full"] }
 tower-http = { version = "0.5", features = ["full"] }
-wasm-bindgen = "=0.2.95"
+wasm-bindgen = "=0.2.100"
 
 # See https://github.com/akesson/cargo-leptos for documentation of all the parameters.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ console_error_panic_hook = "0.1.7"
 console_log = "1"
 http = "1"
 log = "0.4.20"
-simple_logger = "4.2.0"
-thiserror = "1"
+simple_logger = "5.0.0"
+thiserror = "2.0.11"
 tokio = { version = "1.33.0", features = ["full"] }
-tower = { version = "0.4.13", features = ["full"] }
-tower-http = { version = "0.5", features = ["full"] }
+tower = { version = "0.5.2", features = ["full"] }
+tower-http = { version = "0.6.2", features = ["full"] }
 wasm-bindgen = "=0.2.100"
 
 # See https://github.com/akesson/cargo-leptos for documentation of all the parameters.


### PR DESCRIPTION
Updated more deps and tested with the --path 

Updated the versions of tower, tower-http, simple_log and thiserror crates.
I've tested by generating a new project using the --path option, i.e. cargo leptos new --path ./start-axum-workspace-0.7/.
No errors were visible in the browser console.

Holding off on the axum update as there are some problem when attempting to update.
